### PR TITLE
ｖ0.2.0 release merge

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 )
@@ -54,4 +55,16 @@ func (e *fundamental) Format(f fmt.State, c rune) {
 	case 's':
 		fmt.Fprint(f, e.Error())
 	}
+}
+
+// Is is a wrapper for the standard errors.Is().
+// It's returns same result.
+func Is(err, target error) bool {
+	return errors.Is(err, target)
+}
+
+// As is a wrapper for the standard errors.As().
+// It's returns same result.
+func As(err error, target any) bool {
+	return errors.As(err, target)
 }

--- a/errors.go
+++ b/errors.go
@@ -57,13 +57,13 @@ func (e *fundamental) Format(f fmt.State, c rune) {
 	}
 }
 
-// Is is a wrapper for the standard errors.Is().
+// Is the wrapper for the standard errors.Is().
 // It's returns same result.
 func Is(err, target error) bool {
 	return errors.Is(err, target)
 }
 
-// As is a wrapper for the standard errors.As().
+// As the wrapper for the standard errors.As().
 // It's returns same result.
 func As(err error, target any) bool {
 	return errors.As(err, target)

--- a/errors.go
+++ b/errors.go
@@ -59,12 +59,8 @@ func (e *fundamental) Format(f fmt.State, c rune) {
 
 // Is the wrapper for the standard errors.Is().
 // It's returns same result.
-func Is(err, target error) bool {
-	return errors.Is(err, target)
-}
+func Is(err, target error) bool { return errors.Is(err, target) }
 
 // As the wrapper for the standard errors.As().
 // It's returns same result.
-func As(err error, target any) bool {
-	return errors.As(err, target)
-}
+func As(err error, target any) bool { return errors.As(err, target) }

--- a/errors_test.go
+++ b/errors_test.go
@@ -74,3 +74,45 @@ func TestErrorf(t *testing.T) {
 		})
 	}
 }
+
+func TestIs(t *testing.T) {
+	type args struct {
+		err    error
+		target error
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Is(tt.args.err, tt.args.target); got != tt.want {
+				t.Errorf("Is() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAs(t *testing.T) {
+	type args struct {
+		err    error
+		target any
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := As(tt.args.err, tt.args.target); got != tt.want {
+				t.Errorf("As() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"testing"
 )
 
@@ -88,15 +89,15 @@ func TestIs(t *testing.T) {
 		name string
 		args args
 	}{
-		{name: "std error", args: args{err: stdErr, target: fmt.Errorf("wrap: %w", stdErr)}},
-		{name: "predefined error", args: args{err: os.ErrNotExist, target: fmt.Errorf("wrap: %w", os.ErrNotExist)}},
-		{name: "lib error", args: args{err: libErr, target: fmt.Errorf("wrap: %w", libErr)}},
-		{name: "wrap std error", args: args{err: stdErr, target: Wrap(stdErr, "wrap std error")}},
-		{name: "wrap predefined error", args: args{err: os.ErrNotExist, target: Wrap(os.ErrNotExist, "wrap predefined error")}},
-		{name: "wrap lib error", args: args{err: libErr, target: Wrap(libErr, "wrap lib error")}},
-		{name: "wrapf std error", args: args{err: stdErr, target: Wrapf(stdErr, "%s", "wrapf std error")}},
-		{name: "wrapf predefined error", args: args{err: os.ErrNotExist, target: Wrapf(os.ErrNotExist, "%s", "wrapf predefined error")}},
-		{name: "wrapf lib error", args: args{err: libErr, target: Wrapf(libErr, "%s", "wrapf lib error")}},
+		{name: "std error", args: args{err: fmt.Errorf("wrap: %w", stdErr), target: stdErr}},
+		{name: "predefined error", args: args{err: fmt.Errorf("wrap: %w", os.ErrNotExist), target: os.ErrNotExist}},
+		{name: "lib error", args: args{err: fmt.Errorf("wrap: %w", libErr), target: libErr}},
+		{name: "wrap std error", args: args{err: Wrap(stdErr, "wrap std error"), target: stdErr}},
+		{name: "wrap predefined error", args: args{err: Wrap(os.ErrNotExist, "wrap predefined error"), target: os.ErrNotExist}},
+		{name: "wrap lib error", args: args{err: Wrap(libErr, "wrap lib error"), target: libErr}},
+		{name: "wrapf std error", args: args{err: Wrapf(stdErr, "%s", "wrapf std error"), target: stdErr}},
+		{name: "wrapf predefined error", args: args{err: Wrapf(os.ErrNotExist, "%s", "wrapf predefined error"), target: os.ErrNotExist}},
+		{name: "wrapf lib error", args: args{err: Wrapf(libErr, "%s", "wrapf lib error"), target: libErr}},
 		{name: "error is nil", args: args{err: nil, target: nil}},
 	}
 	for _, tt := range tests {
@@ -114,8 +115,14 @@ func TestIs(t *testing.T) {
 	}
 }
 
+type customError struct {
+	msg string
+}
+
+func (c customError) Error() string { return c.msg }
+
 func TestAs(t *testing.T) {
-	err := New("lib error")
+	err := customError{msg: "error"}
 	type args struct {
 		err    error
 		target any
@@ -124,16 +131,21 @@ func TestAs(t *testing.T) {
 		name string
 		args args
 	}{
-		{name: "lib error", args: args{err: err, target: new(fundamental)}},
-		{name: "stdwrap error", args: args{err: fmt.Errorf("wrap: %w", err), target: new(fundamental)}},
-		{name: "wrap lib error", args: args{err: Wrap(err, "wrap error"), target: new(fundamental)}},
-		{name: "wrapf lib error", args: args{err: Wrapf(err, "%s", "wrapf error"), target: new(fundamental)}},
+		{name: "lib error", args: args{err: err, target: new(customError)}},
+		{name: "stdwrap error", args: args{err: fmt.Errorf("wrap: %w", err), target: new(customError)}},
+		{name: "wrap lib error", args: args{err: Wrap(err, "wrap error"), target: new(customError)}},
+		{name: "wrapf lib error", args: args{err: Wrapf(err, "%s", "wrapf error"), target: new(customError)}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			want := errors.As(tt.args.err, &tt.args.target)
-			if got := As(tt.args.err, &tt.args.target); got != want {
+			want := errors.As(tt.args.err, tt.args.target)
+			if got := As(tt.args.err, tt.args.target); got != want {
 				t.Errorf("As() returns different results of errors.As(). result=%v, want %v", got, want)
+			}
+
+			f := tt.args.target.(*customError)
+			if !reflect.DeepEqual(err, *f) {
+				t.Errorf("set target error failed: %v", f)
 			}
 		})
 	}


### PR DESCRIPTION
# What's new
- provides errors.Is() and errors.As() in standard errors.